### PR TITLE
Return attribute name and id. fixes #12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Depends: R (>= 3.3.0)
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Imports: dplyr, 
     rlang,
     RNetCDF,

--- a/R/nc_att.R
+++ b/R/nc_att.R
@@ -10,7 +10,8 @@
 #' @param attribute name or index (zero based) of attribute
 #' @param ... ignored
 #'
-#' @return data frame of attribute 
+#' @return data frame of attribute with numeric id, character attribute name,
+#' character or numeric variable id or name depending on input, and attribute value. 
 #' @export
 #'
 #' @examples
@@ -27,7 +28,9 @@ nc_att <- function(x, variable, attribute, ...) {
 nc_att.NetCDF <- function(x, variable, attribute, ...) {
  att <- RNetCDF::att.get.nc(x, variable, attribute)
 
- faster_as_tibble(list(attribute = attribute, variable = variable, value = list(att)))
+ att_info <- RNetCDF::att.inq.nc(x, variable, attribute)
+ 
+ faster_as_tibble(list(id = att_info$id, name = att_info$name, variable = variable, value = list(att)))
 # structure(list(attribute = attribute, variable = variable, value = list(boom = att)), class = "data.frame")
  
 }

--- a/man/nc_att.Rd
+++ b/man/nc_att.Rd
@@ -22,7 +22,8 @@ nc_att(x, variable, attribute, ...)
 \item{...}{ignored}
 }
 \value{
-data frame of attribute
+data frame of attribute with numeric id, character attribute name,
+character or numeric variable id or name depending on input, and attribute value.
 }
 \description{
 Variable attributes are number 0:(n-1). Global attributes are indexed

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -6,9 +6,12 @@ test_that("attributes works", {
   testthat::skip_on_cran()
   met <- nc_meta(f)
   da <- nc_atts(f) %>% expect_s3_class("tbl_df") %>% 
-    expect_named(c("attribute", "variable", "value")) 
+    expect_named(c("id", "name", "variable", "value")) 
   expect_that(nrow(da), equals(87L))
   expect_that(da$value, is_a("list"))
+  
+  da <- nc_atts(f, add_names = TRUE) %>% expect_s3_class("tbl_df") %>% 
+    expect_named(c("id", "name", "variable", "value")) 
  })
 test_that("attributes from Thredds works", {
   context("avoiding thredds tests for RNetCDF")
@@ -16,7 +19,7 @@ test_that("attributes from Thredds works", {
   skip_on_travis()
   
     du <- nc_atts(u) %>%  expect_s3_class("tbl_df") %>% 
-    expect_named(c("attribute", "variable", "value"))
+    expect_named(c("id", "name", "variable", "value"))
   expect_that(nrow(du), equals(119L))
   expect_that(du$value, is_a("list"))
   
@@ -26,10 +29,13 @@ test_that("individual attribute inquiry works", {
   testthat::skip_on_cran()
   
   nc_att(f, 0, 0) %>% expect_s3_class("tbl_df") %>% 
-    expect_named(c("attribute", "variable", "value")) 
+    expect_named(c("id", "name", "variable", "value")) 
   a3 <- nc_att(f, 0, 3)  
-  expect_that(a3$attribute, equals(3.0))
+  expect_that(a3$id, equals(3.0))
+  expect_that(a3$name, equals("_FillValue"))
   expect_that(a3$value, equals(list(-32767)))
+  
+  expect_identical(a3, nc_att(f, 0, "_FillValue"))
 })
 
 l3binfile <- system.file("extdata", "S2008001.L3b_DAY_CHL.nc", package = "ncmeta")


### PR DESCRIPTION
Would you like an option like "add_name = FALSE" that would maintain the old behavior? This isn't backward compatible in its current form.