### PR TITLE
add variable to grid_mapping_atts

### DIFF
--- a/man/nc_grid_mapping_atts.Rd
+++ b/man/nc_grid_mapping_atts.Rd
@@ -7,20 +7,24 @@
 \alias{nc_grid_mapping_atts.data.frame}
 \title{Get Grid Mapping}
 \usage{
-nc_grid_mapping_atts(x)
+nc_grid_mapping_atts(x, data_variable = NULL)
 
-\method{nc_grid_mapping_atts}{character}(x)
+\method{nc_grid_mapping_atts}{character}(x, data_variable = NULL)
 
-\method{nc_grid_mapping_atts}{NetCDF}(x)
+\method{nc_grid_mapping_atts}{NetCDF}(x, data_variable = NULL)
 
-\method{nc_grid_mapping_atts}{data.frame}(x)
+\method{nc_grid_mapping_atts}{data.frame}(x, data_variable = NULL)
 }
 \arguments{
 \item{x}{open NetCDF object, character file path or url to be
 opened with RNetCDF::open.nc, or data.frame as returned from ncmeta::nc_atts}
+
+\item{data_variable}{character variable of interest}
 }
 \value{
-tibble containing attributes that make up the file's grid_mapping
+tibble containing attributes that make up the file's grid_mapping.
+A data_variable column is included to indicate which data variable the grid
+mapping belongs to.
 }
 \description{
 Get the grid mapping from a NetCDF file

--- a/tests/testthat/test-gridmapping-prj.R
+++ b/tests/testthat/test-gridmapping-prj.R
@@ -27,6 +27,13 @@ test_that("nc_grid_mapping_atts", {
   expect_is(nc_grid_mapping_atts(ncmeta::nc_atts(nc)), "data.frame")
   
   expect_is(nc_grid_mapping_atts(RNetCDF::open.nc(nc)), "data.frame")
+  
+  gm2 <- nc_grid_mapping_atts(nc, data_variable = "prcp")
+  
+  expect_equal(nrow(gm), nrow(gm2))
+  
+  expect_warning(nc_grid_mapping_atts(nc, data_variable = "borked"),
+                 "no grid_mapping attribute found for this variable")
 })
 
 test_that("nc_prj_to_gridmapping returns an empty list if no mapping exists", {


### PR DESCRIPTION
We now have:
```r
nc_grid_mapping_atts(system.file("extdata/daymet_sample.nc", package = "ncmeta"))
# A tibble: 11 x 5
# id name                          variable                value     data_variable
# <dbl> <chr>                         <chr>                   <list>    <chr>        
#   1     0 grid_mapping_name             lambert_conformal_conic <chr [1]> prcp         
# 2     1 longitude_of_central_meridian lambert_conformal_conic <dbl [1]> prcp         
# 3     2 latitude_of_projection_origin lambert_conformal_conic <dbl [1]> prcp         
# 4     3 false_easting                 lambert_conformal_conic <dbl [1]> prcp         
# 5     4 false_northing                lambert_conformal_conic <dbl [1]> prcp         
# 6     5 standard_parallel             lambert_conformal_conic <dbl [2]> prcp         
# 7     6 semi_major_axis               lambert_conformal_conic <dbl [1]> prcp         
# 8     7 inverse_flattening            lambert_conformal_conic <dbl [1]> prcp         
# 9     8 longitude_of_prime_meridian   lambert_conformal_conic <dbl [1]> prcp         
# 10     9 _CoordinateTransformType      lambert_conformal_conic <chr [1]> prcp         
# 11    10 _CoordinateAxisTypes          lambert_conformal_conic <chr [1]> prcp    
```