### PR TITLE
scale_factor_at_central_meridian for Transverse Mercator

### DIFF
--- a/R/nc-gridmapping.R
+++ b/R/nc-gridmapping.R
@@ -176,7 +176,7 @@ GGFP.mercator <- function(al) {
   if(!is.null(al$k)) {
     gm <- c(list(grid_mapping_name = "mercator"),
                       lonProjOrig_gm(al),
-                      scaleFactor_gm(al),
+                      scaleFactorProjOrig_gm(al),
                       falseEastNorth_gm(al),
                       getGeoDatum_gm(al))
   } else {
@@ -194,7 +194,7 @@ GGFP.oblique_mercator <- function(al) {
   gm <- c(list(grid_mapping_name = "oblique_mercator"),
                     latProjOrig_gm(al),
                     lonProjCent_gm(al),
-                    scaleFactor_gm(al),
+                    scaleFactorProjOrig_gm(al),
                     oMerc_gm(al),
                     falseEastNorth_gm(al),
                     getGeoDatum_gm(al))
@@ -215,7 +215,7 @@ GGFP.orthographic <- function(al) {
 #     gm <- c(list(grid_mapping_name = "polar_stereographic"),
 #                       latProjOrig_gm(al),
 #                       stVertLon_gm(al),
-#                       scaleFactor_gm(al),
+#                       scaleFactorProjOrig_gm(al),
 #                       falseEastNorth_gm(al),
 #                       getGeoDatum_gm(al))
 #   } else {
@@ -241,7 +241,7 @@ GGFP.stereographic <- function(al) {
   gm <- c(list(grid_mapping_name = "stereographic"),
                     latProjOrig_gm(al),
                     lonProjOrig_gm(al),
-                    scaleFactor_gm(al),
+                    scaleFactorProjOrig_gm(al),
                     falseEastNorth_gm(al),
                     getGeoDatum_gm(al))
   gm
@@ -251,7 +251,7 @@ GGFP.transverse_mercator <- function(al) {
   gm <- c(list(grid_mapping_name = "transverse_mercator"),
                     latProjOrig_gm(al),
                     lonCentMer_gm(al),
-                    scaleFactor_gm(al),
+                    scaleFactorCentMer_gm(al),
                     falseEastNorth_gm(al),
                     getGeoDatum_gm(al))
   gm
@@ -321,7 +321,11 @@ getGeoDatum_gm <- function(al) {
   }
 }
 
-scaleFactor_gm <- function(al) {
+scaleFactorCentMer_gm <- function(al) {
+  list(scale_factor_at_central_meridian = as.numeric(al$k))
+}
+
+scaleFactorProjOrig_gm <- function(al) {
   list(scale_factor_at_projection_origin = as.numeric(al$k))
 }
 

--- a/R/nc-prj.R
+++ b/R/nc-prj.R
@@ -104,7 +104,7 @@ GPFN.mercator <- function(gm) {
   if(!is.null(gm$scale_factor_at_projection_origin)) {
     projargs <- paste("+proj=merc",
                       lonProjOrig(gm),
-                      scaleFactor(gm),
+                      scaleFactorProjOrig(gm),
                       falseEastNorth(gm),
                       getGeoDatum(gm))
   } else {
@@ -120,7 +120,7 @@ GPFN.oblique_mercator <- function(gm) {
   projargs <- paste("+proj=omerc",
                     latProjOrig(gm),
                     lonProjCent(gm),
-                    scaleFactor(gm),
+                    scaleFactorProjOrig(gm),
                     oMerc(gm),
                     falseEastNorth(gm),
                     getGeoDatum(gm))
@@ -139,7 +139,7 @@ GPFN.polar_stereographic <- function(gm) {
     projargs <- paste("+proj=stere",
                       latProjOrig(gm),
                       stVertLon(gm),
-                      scaleFactor(gm),
+                      scaleFactorProjOrig(gm),
                       falseEastNorth(gm),
                       getGeoDatum(gm))
   } else {
@@ -166,7 +166,7 @@ GPFN.stereographic <- function(gm) {
   projargs <- paste("+proj=stere",
                     latProjOrig(gm),
                     lonProjOrig(gm),
-                    scaleFactor(gm),
+                    scaleFactorProjOrig(gm),
                     falseEastNorth(gm),
                     getGeoDatum(gm))
 }
@@ -175,7 +175,7 @@ GPFN.transverse_mercator <- function(gm) {
   projargs <- paste("+proj=tmerc",
                     latProjOrig(gm),
                     lonCentMer(gm),
-                    scaleFactor(gm),
+                    scaleFactorCentMer(gm),
                     falseEastNorth(gm),
                     getGeoDatum(gm))
 }
@@ -269,7 +269,11 @@ stVertLon <- function(gm) {
   outString <- paste0("+lon_0=", gm$straight_vertical_longitude_from_pole)
 }
 
-scaleFactor <- function(gm) {
+scaleFactorCentMer <- function(gm) {
+  outString <- paste0("+k=", gm$scale_factor_at_central_meridian)
+}
+
+scaleFactorProjOrig <- function(gm) {
   outString <- paste0("+k=", gm$scale_factor_at_projection_origin)
 }
 

--- a/tests/testthat/test-gridmapping-prj.R
+++ b/tests/testthat/test-gridmapping-prj.R
@@ -426,7 +426,7 @@ test_that("transverse_mercator", {
   c <- list(grid_mapping_name = "transverse_mercator",
             longitude_of_central_meridian = -8,
             latitude_of_projection_origin = 53.5,
-            scale_factor_at_projection_origin = 0.99982,
+            scale_factor_at_central_meridian = 0.99982,
             false_easting = 600000,
             false_northing = 750000,
             longitude_of_prime_meridian = 0.0,


### PR DESCRIPTION
This issue is of the same kind as PR #39 : refering to [CF conventions](http://cfconventions.org/cf-conventions/cf-conventions.html#appendix-grid-mappings) the scale factor variable name for transverse mercator is "scale_factor_at_central_meridian" instead of "scale_factor_at_projection_origin" for the others.

This PR fix it changing scaleFactor to scaleFactorCentMer and scaleFactorProjOrig depending on the case of Transverse Mercator or other.
Although diff shows the whole file nc-gridmapping.R has changed, the only change is scaleFactor_gm to scaleFactorCentMer_gm and scaleFactorProjOrig_gm...