### PR TITLE
Handle vectors of different lengths from RNetCDF::var.inq.nc

### DIFF
--- a/R/nc_axes.R
+++ b/R/nc_axes.R
@@ -51,7 +51,7 @@ nc_axes.NetCDF <- function(x, variables = NULL, ...) {
 ## note this is a bit weird, but we have to ensure
 ## we work relative to all axes, so use the hidden function nc_axis_var
 nc_axis_var <- function(x, i) {
-  out <- RNetCDF::var.inq.nc(x, i)
+  out <- RNetCDF::var.inq.nc(x, i)[c("name", "ndims", "dimids")]
   #dimids <- out$dimids
   
   out[sapply(out, is.null)] <- NA

--- a/R/nc_var.R
+++ b/R/nc_var.R
@@ -25,9 +25,17 @@ nc_var.character <- function(x, i) {
 #'@export
 nc_var.NetCDF <- function(x, i) {
   out <- RNetCDF::var.inq.nc(x, i)
-  out$dimids <- NULL
+  # Remove NULL list items:
   out <- out[lengths(out) > 0]
-  dplyr::distinct(tibble::as_tibble(out))
+  # Convert dimids to empty vector when variable is scalar:
+  if (anyNA(out$dimids)) {
+    out$dimids <- integer(0)
+  }
+  # Store vector values as nested lists:
+  vectors <- c("dimids", "chunksizes", "filter_id", "filter_params")
+  listcols <- vectors[vectors %in% names(out)]
+  out[listcols] <- lapply(out[listcols], list)
+  # Transform list to tibble row:
+  tibble::as_tibble_row(out)
 }
-
 


### PR DESCRIPTION
Fixes https://github.com/hypertidy/ncmeta/issues/42

`RNetCDF::var.inq.nc` returns additional elements when the file format is `netcdf4`. Some of these elements are vectors, with lengths that may differ from the number of dimensions in a variable. For example, `chunksizes` either has one element per dimension, or it is NULL for contiguous storage. Also, recent NetCDF library versions provide a filter API that can apply multiple filters to each variable, and descriptions of the filters are returned in vectors `filter_id` and `filter_params`, whose lengths are unrelated to the variable's dimensions.

To handle vectors of different lengths in the output from `nc_var`, vector elements are stored as list columns within the tibble produced by `nc_var`.

Also, the tibble produced within `nc_axes` does not require all elements from `RNetCDF::var.inq.nc`, so selecting only those required avoids the problem of differing vector lengths.