### PR TITLE
nc_var: only keep items from RNetCDF::var.inq.nc that fit in a tibble row

### DIFF
--- a/R/nc_var.R
+++ b/R/nc_var.R
@@ -25,8 +25,6 @@ nc_var.character <- function(x, i) {
 #'@export
 nc_var.NetCDF <- function(x, i) {
   out <- RNetCDF::var.inq.nc(x, i)
-  # Remove NULL list items:
-  out <- out[lengths(out) > 0]
   # Convert dimids to empty vector when variable is scalar:
   if (anyNA(out$dimids)) {
     out$dimids <- integer(0)
@@ -35,6 +33,8 @@ nc_var.NetCDF <- function(x, i) {
   vectors <- c("dimids", "chunksizes", "filter_id", "filter_params")
   listcols <- vectors[vectors %in% names(out)]
   out[listcols] <- lapply(out[listcols], list)
+  # Keep only list items with length 1:
+  out <- out[lengths(out) == 1]
   # Transform list to tibble row:
   tibble::as_tibble_row(out)
 }


### PR DESCRIPTION
Although the solution in #44 works for now, it would break if new vector items were added to the output of RNetCDF::var.inq.nc. This could occur if RNetCDF is extended to support new features in the NetCDF library. The changes in this PR should ensure that nc_var continues to work, by excluding unknown vector items that are returned by `var.inq.nc`.